### PR TITLE
fix: newline input on windows

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub struct Config {
 
 pub fn login() {
     print!("Username: ");
-    let name = read!("{}\n");
+    let name = read!();
     let password = rpassword::prompt_password("Password: ").unwrap();
     let timestamp = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,8 @@ fn select_semester(semesters: &[Semester]) -> Semester {
         }
     }
     print!("Choose a semester [{}]: ", current_semester);
-    let input: String = read!("{}\n");
+    let mut input: String = read!("{}\n");
+    input = input.trim().to_string();
     if !input.is_empty() {
         current_semester = input.parse().expect("Input not an integer");
     }


### PR DESCRIPTION
Fix taking in input when newline is \r\n on windows.