### PR TITLE
Revert "feat(GPA): add GPA delta"

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,3 @@ cargo install --path .
 
 No tls-xb only fetches data from <https://tsinglanstudent.schoolis.cn/api>
 to calculate your GPA, which does not expose an api to change your GPA.
-
-### What is GPA Delta?
-
-GPA Delta is the change in GPA when the grade of a subject increases or drops
-(when not changing to or from F).
-For example, if English increases from A to A+,
-GPA Delta would be the resulting change in GPA.

--- a/src/gpa.rs
+++ b/src/gpa.rs
@@ -77,7 +77,6 @@ pub fn score_level_from_score(
 pub struct CalculatedGPA {
     pub weighted_gpa: f64,
     pub unweighted_gpa: f64,
-    pub gpa_delta: f64,
     pub max_gpa: f64,
 }
 
@@ -92,11 +91,9 @@ pub fn calculate_gpa(subjects: &[Subject]) -> CalculatedGPA {
         total_unweighted_gpa += subject.unweighted_gpa * subject.weight;
         total_max_gpa += subject.max_gpa * subject.weight;
     }
-    let gpa_delta = 0.3 / total_weight;
     CalculatedGPA {
         weighted_gpa: total_weighted_gpa / total_weight,
         unweighted_gpa: total_unweighted_gpa / total_weight,
-        gpa_delta,
         max_gpa: total_max_gpa / total_weight,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,6 @@ async fn main() {
         "Calculated Unweighted GPA: {:.2}",
         calculated_gpa.unweighted_gpa
     );
-    println!("GPA Delta: {:.2}", calculated_gpa.gpa_delta);
 }
 
 fn select_semester(semesters: &[Semester]) -> Semester {


### PR DESCRIPTION
This reverts commit c2a6b4f330bcf863c3e189b08da283ed5ec29fc7.

It turns out that the gpa difference between letters (e.g A- and B+) is 0.4 instead of the usual 0.3, causing the initial assumption about gpa delta to be false.

I think it is best to just remove GPA delta instead of accounting for more edge cases.