### PR TITLE
Added date and semester selection to the calendar function.

### DIFF
--- a/src/semester.rs
+++ b/src/semester.rs
@@ -1,6 +1,7 @@
 use crate::calendar::date_parser;
 use chrono::{DateTime, FixedOffset};
 use serde::Deserialize;
+use chrono::Utc;
 
 #[derive(Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
feat(calendar): add date parsing for ICalArgs and update semester selection logic

Now, you can use command

```ps1
tls-xb ical 20250202 20250701
```
to assign a date interval or 
```ps1
tls-xb ical
```
to enter a semester selection.

<img width="1060" height="793" alt="image" src="https://github.com/user-attachments/assets/3365e446-50d0-4763-a4b7-fd30a61cdaf1" />
